### PR TITLE
fix: remove derive block expr to fix LSP type inference

### DIFF
--- a/rustify_derive/src/parse.rs
+++ b/rustify_derive/src/parse.rs
@@ -219,7 +219,7 @@ pub(crate) fn fields_to_struct(fields: &[Field], attrs: &[Meta]) -> proc_macro2:
         .collect::<Vec<proc_macro2::TokenStream>>();
 
     quote! {
-        #[derive(Serialize)]
+        #[derive(serde::Serialize)]
         #(#attrs)*
         struct __Temp<'a> {
             #(#def)*


### PR DESCRIPTION
This updates `rustify_derive` to remove the block expression that the `impl Endpoint` was wrapped in.

This resolves an issue where `rust-analyzer` is unable to infer the type of `Endpoint::Response` in some cases.